### PR TITLE
Create shared layout with persistent header and footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,19 @@ import { AnimatePresence } from "framer-motion";
 import Hero from "./components/Hero";
 import Portfolio from "./pages/Portfolio";
 import ProjectDetail from "./pages/ProjectDetail";
+import PageLayout from "./components/PageLayout";
 
 const AnimatedRoutes: React.FC = () => {
   const location = useLocation();
 
   return (
     <AnimatePresence mode="wait">
-      <Routes location={location} key={location.pathname}>
+      <Routes location={location} key={location.pathname === "/" ? location.pathname : "layout"}>
         <Route path="/" element={<Hero />} />
-        <Route path="/portfolio" element={<Portfolio />} />
-        <Route path="/projects/:id" element={<ProjectDetail />} />
+        <Route element={<PageLayout />}>
+          <Route path="/portfolio" element={<Portfolio />} />
+          <Route path="/projects/:id" element={<ProjectDetail />} />
+        </Route>
       </Routes>
     </AnimatePresence>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+const easeSoft = [0.4, 0, 0.2, 1] as const;
+
+const Footer: React.FC = () => {
+  const year = new Date().getFullYear();
+
+  return (
+    <motion.footer
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: easeSoft, delay: 0.15 }}
+      className="w-full border-t border-white/10 bg-black/60 backdrop-blur-sm"
+    >
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-6 py-6 text-[0.6rem] uppercase tracking-[0.25em] text-white/40 sm:flex-row sm:items-center sm:justify-between">
+        <span>© {year} mickeyshide</span>
+        <span className="text-white/30">building async backends &amp; playful systems</span>
+      </div>
+    </motion.footer>
+  );
+};
+
+export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { FiMail } from "react-icons/fi";
+import { FaTelegramPlane } from "react-icons/fa";
+
+const easeSoft = [0.4, 0, 0.2, 1] as const;
+
+const Header: React.FC = () => {
+  return (
+    <motion.header
+      initial={{ opacity: 0, y: -12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: easeSoft, delay: 0.1 }}
+      className="w-full border-b border-white/10 bg-black/60 backdrop-blur-sm"
+    >
+      <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-6 py-6 text-[0.7rem] uppercase tracking-[0.2em] text-white/50 sm:flex-row">
+        <img
+          src="/imgs/shide.png"
+          alt="logo"
+          loading="lazy"
+          className="h-10 w-auto invert contrast-[250%] brightness-[300%] saturate-0 mix-blend-screen transition-opacity duration-700 ease-out"
+        />
+        <div className="flex gap-4 text-[0.6rem]">
+          <a href="mailto:MICKEYSHIDE@GMAIL.COM" className="flex flex-row items-center gap-2 hover:text-white transition">
+            <FiMail size={16} />
+            <span className="hidden sm:block">mickeyshide@gmail.com</span>
+          </a>
+          <a
+            href="https://t.me/mickeyshide"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-row items-center gap-2 hover:text-white transition"
+          >
+            <FaTelegramPlane size={16} />
+            <span className="hidden sm:block">mickeyshide</span>
+          </a>
+        </div>
+      </div>
+    </motion.header>
+  );
+};
+
+export default Header;

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Outlet, useLocation } from "react-router-dom";
+import Header from "./Header";
+import Footer from "./Footer";
+
+const easeSoft = [0.4, 0, 0.2, 1] as const;
+
+const PageLayout: React.FC = () => {
+  const location = useLocation();
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-black text-white">
+      <Header />
+      <AnimatePresence mode="wait">
+        <motion.main
+          key={location.pathname}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -12 }}
+          transition={{ duration: 0.5, ease: easeSoft }}
+          className="flex-1 overflow-hidden px-6 py-8"
+        >
+          <div className="mx-auto flex h-full w-full max-w-6xl flex-col items-center">
+            <Outlet />
+          </div>
+        </motion.main>
+      </AnimatePresence>
+      <Footer />
+    </div>
+  );
+};
+
+export default PageLayout;

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
-import { FiMail } from "react-icons/fi";
-import { FaTelegramPlane } from "react-icons/fa";
 
 type Project = {
   title: string;
@@ -45,7 +43,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
       initial="hidden"
       animate="visible"
       custom={0.2 + index * 0.08}
-      className="py-2 rounded-sm w-full max-w-[240px] flex flex-col justify-center items-center hover:border-white/30 transition-colors"
+      className="flex w-full max-w-[240px] flex-col items-center justify-center rounded-sm py-2 transition-colors hover:border-white/30"
       whileHover={{ scale: 1.03 }}
     >
       {!imgError && (
@@ -69,101 +67,59 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, index }) => {
 };
 
 const Portfolio: React.FC = () => {
-
   return (
-    <motion.div
-      className="px-6 min-h-[100dvh] bg-black text-white font-mono flex flex-col items-center justify-start py-6 overflow-hidden"
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, ease: easeSoft }}
-    >
-      {/* header */}
-      <motion.header
+    <div className="flex w-full flex-1 flex-col items-center text-center">
+      <motion.h1
         variants={fadeIn}
         initial="hidden"
         animate="visible"
-        custom={0.15}
-        className="w-full max-w-6xl flex flex-col sm:flex-row justify-between items-center text-[0.7rem] text-white/50 uppercase tracking-[0.2em] mb-10 gap-4"
+        custom={0.25}
+        className="mb-4 text-[clamp(2rem,6vw,4rem)] uppercase tracking-tight text-white/90 pixel-font"
       >
-        <img
-          src="/imgs/shide.png"
-          alt="logo"
-          loading="lazy"
-          className="invert h-10 w-auto contrast-[250%] brightness-[300%] saturate-0 mix-blend-screen transition-opacity duration-700 ease-out"
-        />
-        <div className="flex gap-4 text-[0.6rem]">
-          <a href="mailto:MICKEYSHIDE@GMAIL.COM" className="flex flex-row gap-2 hover:text-white transition">
-            <FiMail size={16} />
-            <span className="hidden sm:block">mickeyshide@gmail.com</span>
-          </a>
-          <a
-            href="https://t.me/mickeyshide"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex flex-row gap-2 hover:text-white transition"
-          >
-            <FaTelegramPlane size={16} />
-            <span className="hidden sm:block">mickeyshide</span>
-          </a>
-        </div>
-      </motion.header>
+        python backend developer
+      </motion.h1>
 
-      {/* main */}
-      <main className="text-center w-full max-w-6xl flex flex-col items-center">
-        <motion.h1
-          variants={fadeIn}
-          initial="hidden"
-          animate="visible"
-          custom={0.25}
-          className="text-[clamp(2rem,6vw,4rem)] uppercase tracking-tight text-white/90 pixel-font mb-4"
-        >
-          python backend developer
-        </motion.h1>
-
-        {/* profile */}
-        <motion.div
-          variants={fadeIn}
-          initial="hidden"
-          animate="visible"
-          custom={0.35}
-          className="flex flex-col items-center text-center text-white/70 text-[0.75rem] tracking-[0.15em] mb-16"
-        >
-          <div className="flex flex-row gap-2">
-            <motion.img
-              src="/imgs/profile.png"
-              alt="profile"
-              className="w-24 h-24 rounded-sm object-cover invert contrast-[180%] brightness-[220%] saturate-0 mix-blend-screen"
-            />
-            <div className="flex flex-col justify-center text-start">
-              <span className="text-white/90 pixel-font text-[1rem]">Nikita</span>
-              <span className="text-white/90 pixel-font text-[1rem]">23yo</span>
-              <span className="text-white/90 pixel-font text-[1rem]">Moscow, RU</span>
-            </div>
+      <motion.div
+        variants={fadeIn}
+        initial="hidden"
+        animate="visible"
+        custom={0.35}
+        className="mb-16 flex flex-col items-center text-center text-[0.75rem] tracking-[0.15em] text-white/70"
+      >
+        <div className="flex flex-row gap-2">
+          <motion.img
+            src="/imgs/profile.png"
+            alt="profile"
+            className="h-24 w-24 rounded-sm object-cover invert contrast-[180%] brightness-[220%] saturate-0 mix-blend-screen"
+          />
+          <div className="flex flex-col justify-center text-start">
+            <span className="pixel-font text-[1rem] text-white/90">Nikita</span>
+            <span className="pixel-font text-[1rem] text-white/90">23yo</span>
+            <span className="pixel-font text-[1rem] text-white/90">Moscow, RU</span>
           </div>
-          <span className="text-white/40 mt-2 px-4">
-            fastapi / sqlalchemy /
-            postgresql / redis / docker / pytest / celery
-          </span>
-        </motion.div>
-
-        {/* projects */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 justify-items-center">
-          {projects.map((project, index) => (
-            <ProjectCard key={project.slug} project={project} index={index} />
-          ))}
         </div>
+        <span className="mt-2 px-4 text-white/40">
+          fastapi / sqlalchemy /
+          postgresql / redis / docker / pytest / celery
+        </span>
+      </motion.div>
 
-        <motion.p
-          variants={fadeIn}
-          initial="hidden"
-          animate="visible"
-          custom={0.55}
-          className="text-[0.7rem] text-white/30 tracking-[0.25em] uppercase pt-20"
-        >
-          Updated: 07.10.2025
-        </motion.p>
-      </main>
-    </motion.div>
+      <div className="grid grid-cols-1 justify-items-center gap-8 sm:grid-cols-2 md:grid-cols-3">
+        {projects.map((project, index) => (
+          <ProjectCard key={project.slug} project={project} index={index} />
+        ))}
+      </div>
+
+      <motion.p
+        variants={fadeIn}
+        initial="hidden"
+        animate="visible"
+        custom={0.55}
+        className="pt-20 text-[0.7rem] uppercase tracking-[0.25em] text-white/30"
+      >
+        Updated: 07.10.2025
+      </motion.p>
+    </div>
   );
 };
 

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { FiMail } from "react-icons/fi";
-import { FaTelegramPlane } from "react-icons/fa";
 import { Link, useParams } from "react-router-dom";
 
 type ProjectContent = {
@@ -71,130 +69,93 @@ const ProjectDetail: React.FC = () => {
   }, []);
 
   return (
-    <motion.div
-      className="px-6 min-h-[100dvh] bg-black text-white font-mono flex flex-col items-center justify-start py-6 overflow-hidden"
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, ease: easeSoft }}
-    >
-      <motion.header
+    <div className="flex w-full flex-1 flex-col items-center gap-16 text-center">
+      <motion.section
         variants={fadeIn}
         initial="hidden"
         animate="visible"
-        custom={0.12}
-        className="w-full max-w-6xl flex flex-col sm:flex-row justify-between items-center text-[0.7rem] text-white/50 uppercase tracking-[0.2em] mb-10 gap-4"
+        custom={0.9}
+        className="flex flex-col items-center gap-6"
       >
-        <img
-          src="/imgs/shide.png"
-          alt="logo"
-          loading="lazy"
-          className="invert h-10 w-auto contrast-[250%] brightness-[300%] saturate-0 mix-blend-screen transition-opacity duration-700 ease-out"
-        />
-        <div className="flex gap-4 text-[0.6rem]">
-          <a href="mailto:MICKEYSHIDE@GMAIL.COM" className="flex flex-row gap-2 hover:text-white transition">
-            <FiMail size={16} />
-            <span className="hidden sm:block">mickeyshide@gmail.com</span>
-          </a>
-          <a
-            href="https://t.me/mickeyshide"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex flex-row gap-2 hover:text-white transition"
-          >
-            <FaTelegramPlane size={16} />
-            <span className="hidden sm:block">mickeyshide</span>
-          </a>
-        </div>
-      </motion.header>
-
-      <main className="text-center w-full max-w-6xl flex flex-col items-center gap-16">
-        <motion.section
-          variants={fadeIn}
-          initial="hidden"
-          animate="visible"
-          custom={0.9}
-          className="flex flex-col items-center gap-6"
+        <motion.h1
+          className="text-[clamp(2.5rem,7vw,5rem)] uppercase tracking-tight text-white/90 pixel-font"
+          initial={{ opacity: 0, y: 18 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.22, duration: 0.45, ease: easeSoft }}
         >
-          <motion.h1
-            className="text-[clamp(2.5rem,7vw,5rem)] uppercase tracking-tight text-white/90 pixel-font"
-            initial={{ opacity: 0, y: 18 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.22, duration: 0.45, ease: easeSoft }}
-          >
-            {project.title}
-          </motion.h1>
-          <p className="text-white/60 text-sm sm:text-base leading-relaxed max-w-2xl">
-            {project.description}
-          </p>
-          <div className="flex flex-wrap justify-center gap-3 text-[0.65rem] sm:text-xs tracking-[0.25em] text-white/50 uppercase">
-            {project.technologies.map((tech, techIndex) => (
-              <motion.span
-                key={tech}
-                variants={fadeIn}
-                initial="hidden"
-                animate="visible"
-                custom={0.3 + techIndex * 0.05}
-                className="px-3 py-1 border border-white/10 bg-white/5 backdrop-blur-sm"
-              >
-                {tech}
-              </motion.span>
-            ))}
-          </div>
-        </motion.section>
-
-        <motion.section
-          variants={fadeIn}
-          initial="hidden"
-          animate="visible"
-          custom={0.35}
-          className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8"
-        >
-          {project.gallery.map((src, index) => {
-            const isLoaded = loadedImages[src];
-            return (
-              <motion.div
-                key={src}
-                className="relative overflow-hidden rounded-sm border border-white/5 bg-white/5"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.4 + index * 0.1, duration: 0.45, ease: easeSoft }}
-                whileHover={{ y: -8, scale: 1.01 }}
-              >
-                <motion.img
-                  src={src}
-                  alt={`${project.title} preview ${index + 1}`}
-                  className={`w-full h-full object-cover select-none transition-all duration-700 ease-out ${
-                    isLoaded ? "blur-0 opacity-100" : "blur-md opacity-0"
-                  }`}
-                  onLoad={() => markLoaded(src)}
-                />
-                {!isLoaded && (
-                  <div className="absolute inset-0 bg-white/5 animate-pulse" aria-hidden />
-                )}
-              </motion.div>
-            );
-          })}
-        </motion.section>
-
-        <motion.div
-          variants={fadeIn}
-          initial="hidden"
-          animate="visible"
-          custom={0.5}
-          className="w-full flex justify-center"
-        >
-          <Link
-            to="/portfolio"
-            className="flex items-center gap-2 text-white/60 hover:text-white transition text-sm uppercase tracking-[0.2em]"
-          >
-            <motion.span whileHover={{ x: -4 }} className="text-lg">
-              ←
+          {project.title}
+        </motion.h1>
+        <p className="max-w-2xl text-sm leading-relaxed text-white/60 sm:text-base">
+          {project.description}
+        </p>
+        <div className="flex flex-wrap justify-center gap-3 text-[0.65rem] uppercase tracking-[0.25em] text-white/50 sm:text-xs">
+          {project.technologies.map((tech, techIndex) => (
+            <motion.span
+              key={tech}
+              variants={fadeIn}
+              initial="hidden"
+              animate="visible"
+              custom={0.3 + techIndex * 0.05}
+              className="border border-white/10 bg-white/5 px-3 py-1 backdrop-blur-sm"
+            >
+              {tech}
             </motion.span>
-            <span>back to portfolio</span>
-          </Link>
-        </motion.div>
-      </main>
-    </motion.div>
+          ))}
+        </div>
+      </motion.section>
+
+      <motion.section
+        variants={fadeIn}
+        initial="hidden"
+        animate="visible"
+        custom={0.35}
+        className="grid w-full grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3"
+      >
+        {project.gallery.map((src, index) => {
+          const isLoaded = loadedImages[src];
+          return (
+            <motion.div
+              key={src}
+              className="relative overflow-hidden rounded-sm border border-white/5 bg-white/5"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.4 + index * 0.1, duration: 0.45, ease: easeSoft }}
+              whileHover={{ y: -8, scale: 1.01 }}
+            >
+              <motion.img
+                src={src}
+                alt={`${project.title} preview ${index + 1}`}
+                className={`h-full w-full select-none object-cover transition-all duration-700 ease-out ${
+                  isLoaded ? "blur-0 opacity-100" : "blur-md opacity-0"
+                }`}
+                onLoad={() => markLoaded(src)}
+              />
+              {!isLoaded && (
+                <div className="absolute inset-0 animate-pulse bg-white/5" aria-hidden />
+              )}
+            </motion.div>
+          );
+        })}
+      </motion.section>
+
+      <motion.div
+        variants={fadeIn}
+        initial="hidden"
+        animate="visible"
+        custom={0.5}
+        className="flex w-full justify-center"
+      >
+        <Link
+          to="/portfolio"
+          className="flex items-center gap-2 text-sm uppercase tracking-[0.2em] text-white/60 transition hover:text-white"
+        >
+          <motion.span whileHover={{ x: -4 }} className="text-lg">
+            ←
+          </motion.span>
+          <span>back to portfolio</span>
+        </Link>
+      </motion.div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a shared page layout that renders persistent header and footer elements outside of animated route transitions
- refactor the portfolio and project detail screens to focus on main content within the new layout container
- adjust routing to reuse the layout across portfolio-related pages while keeping the hero screen standalone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e486759a208323af5636d16f774a9b